### PR TITLE
Improve tutorial links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Each Individual tutorial has its own numbered folder.
 ## Tutorials
 
 1. [Making a Clock](https://catlikecoding.com/godot/introduction/1-making-a-clock/)
-2. [Programming a Clock](https://catlikecoding.com/godot/introduction/2-making-a-clock/)
+2. [Programming a Clock](https://catlikecoding.com/godot/introduction/2-programming-a-clock/)
 
 This is a work in progress. More parts will be added in due time.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Each Individual tutorial has its own numbered folder.
 
 1. [Making a Clock](https://catlikecoding.com/godot/introduction/1-making-a-clock/)
 2. [Programming a Clock](https://catlikecoding.com/godot/introduction/2-programming-a-clock/)
+3. [Many Clocks](https://catlikecoding.com/godot/introduction/3-many-clocks/)
 
 This is a work in progress. More parts will be added in due time.
 


### PR DESCRIPTION
## Description

This PR fixes the link inside README.md to the 2nd tutorial (which is currently broken and results in a 404 error page) and adds the link to the 3rd tutorial.

## Testing instructions

1. Click on the links inside README.md.
2. They should open the correct pages.